### PR TITLE
Catch unhandled exception

### DIFF
--- a/M2Mqtt/Net/MqttNetworkChannel.cs
+++ b/M2Mqtt/Net/MqttNetworkChannel.cs
@@ -30,6 +30,7 @@ using System.Net.Sockets;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System;
+using System.Diagnostics;
 
 namespace uPLibrary.Networking.M2Mqtt
 {
@@ -395,7 +396,15 @@ namespace uPLibrary.Networking.M2Mqtt
 #endif
             }
 #if NETSTANDARD1_6
-            this.socket.Shutdown(SocketShutdown.Both);
+            try
+            {
+                this.socket.Shutdown(SocketShutdown.Both);
+            }
+            catch
+            {
+                // An error occurred when attempting to access the socket or socket has been closed
+                // Refer to: https://msdn.microsoft.com/en-us/library/system.net.sockets.socket.shutdown(v=vs.110).aspx
+            }
             this.socket.Dispose();
 #else
             this.socket.Close();


### PR DESCRIPTION
Wrap this.socket.Shutdown in try and catch

There is an issue with unguarded socket.Shutdown call.
If for whatever reason socket is already closed calling Shutdown will throw and exception and in our case will crash the application.

If possible could you release new version of your nuget package with this bug fix.

Thank you for your nuget package!