### PR TITLE
Added try/catch to prevent unconstrained CPU usage

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -572,7 +572,17 @@ namespace uPLibrary.Networking.M2Mqtt
             // start thread for receiving messages from broker
             Fx.StartThread(this.ReceiveThread);
             
-            MqttMsgConnack connack = (MqttMsgConnack)this.SendReceive(connect);
+            MqttMsgConnack connack = null;
+            try
+            {
+                connack = (MqttMsgConnack)this.SendReceive(connect);
+            }
+            catch (MqttCommunicationException e)
+            {
+                this.isRunning = false;
+                throw;
+            }
+		
             // if connection accepted, start keep alive timer and 
             if (connack.ReturnCode == MqttMsgConnack.CONN_ACCEPTED)
             {


### PR DESCRIPTION
Added exception handling around the SendReceive call that happens right after Connect in MqttClient.  Without a try/catch here, if you connect to a broker that is allowing connections but is otherwise in a bad state, the paho library will spin up to use an entire CPU core immediately (seen on a box with 4 cores, this was 25% CPU usage), then after a few minutes it jumps to 50%, then so on until 100% of the CPU is being used and the box crashes.

Per multiple pull requests on the original project managed by Eclipse (which appears to be a dead project as no changes have been made since 2016), this can be reproduced by setting up a broker with MaxConnections=1 then connecting 2 clients.