### PR TITLE
Fixing issue with long live connections & DNS updates

### DIFF
--- a/M2Mqtt/Net/MqttNetworkChannel.cs
+++ b/M2Mqtt/Net/MqttNetworkChannel.cs
@@ -237,7 +237,7 @@ namespace uPLibrary.Networking.M2Mqtt
         {
             this.socket = new Socket(this.remoteIpAddress.GetAddressFamily(), SocketType.Stream, ProtocolType.Tcp);
             // try connection to the broker
-            this.socket.Connect(new IPEndPoint(this.remoteIpAddress, this.remotePort));
+            this.socket.Connect(this.remoteHostName, this.remotePort);
 
 #if SSL
             // secure channel requested


### PR DESCRIPTION
We have long running daemons (clients) in the wild using this library, to help balance load and scale we often bump the clients off a server, they normally reconnect to a new server immediately but this library will continue to use the first IP address it found for a server indefinately, this is clearly the wrong behaviour as our IP addresses change over time and we expect the reconnect logic to use the hostname rather than the first IP address.

This PR fixes that issue by switching to the remoteHostName field.