### PR TITLE
Change for ALPN support.

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -277,7 +277,7 @@ namespace uPLibrary.Networking.M2Mqtt
         public MqttClient(IPAddress brokerIpAddress, int brokerPort, bool secure, X509Certificate caCert, X509Certificate clientCert, MqttSslProtocols sslProtocol)
         {
 #if !(MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK)
-            this.Init(brokerIpAddress.ToString(), brokerPort, secure, caCert, clientCert, sslProtocol, null, null);
+            this.Init(brokerIpAddress.ToString(), brokerPort, secure, caCert, clientCert, sslProtocol, null, null, null);
 #else
             this.Init(brokerIpAddress.ToString(), brokerPort, secure, caCert, clientCert, sslProtocol);
 #endif
@@ -313,7 +313,7 @@ namespace uPLibrary.Networking.M2Mqtt
 #endif
         {
 #if !(MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK || WINDOWS_APP || WINDOWS_PHONE_APP)
-            this.Init(brokerHostName, brokerPort, secure, caCert, clientCert, sslProtocol, null, null);
+            this.Init(brokerHostName, brokerPort, secure, caCert, clientCert, sslProtocol, null, null, null);
 #elif (WINDOWS_APP || WINDOWS_PHONE_APP)
             this.Init(brokerHostName, brokerPort, secure, sslProtocol);
 #else
@@ -371,8 +371,16 @@ namespace uPLibrary.Networking.M2Mqtt
             RemoteCertificateValidationCallback userCertificateValidationCallback,
             LocalCertificateSelectionCallback userCertificateSelectionCallback)
         {
-            this.Init(brokerHostName, brokerPort, secure, caCert, clientCert, sslProtocol, userCertificateValidationCallback, userCertificateSelectionCallback);
+            this.Init(brokerHostName, brokerPort, secure, caCert, clientCert, sslProtocol, userCertificateValidationCallback, userCertificateSelectionCallback, null);
         }
+
+        public MqttClient(string brokerHostName, int brokerPort, bool secure, X509Certificate caCert, X509Certificate clientCert, MqttSslProtocols sslProtocol,
+    RemoteCertificateValidationCallback userCertificateValidationCallback,
+    LocalCertificateSelectionCallback userCertificateSelectionCallback, List<string> ALPNProtocols)
+        {
+            this.Init(brokerHostName, brokerPort, secure, caCert, clientCert, sslProtocol, userCertificateValidationCallback, userCertificateSelectionCallback, ALPNProtocols);
+        }
+
 #endif
 
 #if BROKER
@@ -423,9 +431,12 @@ namespace uPLibrary.Networking.M2Mqtt
 #if !(MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK || WINDOWS_APP || WINDOWS_PHONE_APP)
         /// <param name="userCertificateSelectionCallback">A RemoteCertificateValidationCallback delegate responsible for validating the certificate supplied by the remote party</param>
         /// <param name="userCertificateValidationCallback">A LocalCertificateSelectionCallback delegate responsible for selecting the certificate used for authentication</param>
+        /// <param name="alpnProtocols">list of protocols for ALPN</param>
+        /// 
         private void Init(string brokerHostName, int brokerPort, bool secure, X509Certificate caCert, X509Certificate clientCert, MqttSslProtocols sslProtocol,
             RemoteCertificateValidationCallback userCertificateValidationCallback,
-            LocalCertificateSelectionCallback userCertificateSelectionCallback)
+            LocalCertificateSelectionCallback userCertificateSelectionCallback,
+            List<string> alpnProtocols)
 #elif (WINDOWS_APP || WINDOWS_PHONE_APP)
         private void Init(string brokerHostName, int brokerPort, bool secure, MqttSslProtocols sslProtocol)
 #else
@@ -468,7 +479,7 @@ namespace uPLibrary.Networking.M2Mqtt
 
             // create network channel
 #if !(MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK || WINDOWS_APP || WINDOWS_PHONE_APP)
-            this.channel = new MqttNetworkChannel(this.brokerHostName, this.brokerPort, secure, caCert, clientCert, sslProtocol, userCertificateValidationCallback, userCertificateSelectionCallback);
+            this.channel = new MqttNetworkChannel(this.brokerHostName, this.brokerPort, secure, caCert, clientCert, sslProtocol, userCertificateValidationCallback, userCertificateSelectionCallback, alpnProtocols);
 #elif (WINDOWS_APP || WINDOWS_PHONE_APP)
             this.channel = new MqttNetworkChannel(this.brokerHostName, this.brokerPort, secure, sslProtocol);
 #else

--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -277,7 +277,7 @@ namespace uPLibrary.Networking.M2Mqtt
         public MqttClient(IPAddress brokerIpAddress, int brokerPort, bool secure, X509Certificate caCert, X509Certificate clientCert, MqttSslProtocols sslProtocol)
         {
 #if !(MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK)
-            this.Init(brokerIpAddress.ToString(), brokerPort, secure, caCert, clientCert, sslProtocol, null, null, null);
+            this.Init(brokerIpAddress.ToString(), brokerPort, secure, caCert, clientCert, sslProtocol, null, null);
 #else
             this.Init(brokerIpAddress.ToString(), brokerPort, secure, caCert, clientCert, sslProtocol);
 #endif
@@ -313,7 +313,7 @@ namespace uPLibrary.Networking.M2Mqtt
 #endif
         {
 #if !(MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK || WINDOWS_APP || WINDOWS_PHONE_APP)
-            this.Init(brokerHostName, brokerPort, secure, caCert, clientCert, sslProtocol, null, null, null);
+            this.Init(brokerHostName, brokerPort, secure, caCert, clientCert, sslProtocol, null, null);
 #elif (WINDOWS_APP || WINDOWS_PHONE_APP)
             this.Init(brokerHostName, brokerPort, secure, sslProtocol);
 #else
@@ -367,20 +367,14 @@ namespace uPLibrary.Networking.M2Mqtt
         /// <param name="sslProtocol">SSL/TLS protocol version</param>
         /// <param name="userCertificateValidationCallback">A RemoteCertificateValidationCallback delegate responsible for validating the certificate supplied by the remote party</param>
         /// <param name="userCertificateSelectionCallback">A LocalCertificateSelectionCallback delegate responsible for selecting the certificate used for authentication</param>
+        /// <param name="alpnProtocols">list of protocols for ALPN</param>
         public MqttClient(string brokerHostName, int brokerPort, bool secure, X509Certificate caCert, X509Certificate clientCert, MqttSslProtocols sslProtocol,
             RemoteCertificateValidationCallback userCertificateValidationCallback,
-            LocalCertificateSelectionCallback userCertificateSelectionCallback)
-        {
-            this.Init(brokerHostName, brokerPort, secure, caCert, clientCert, sslProtocol, userCertificateValidationCallback, userCertificateSelectionCallback, null);
-        }
-
-        public MqttClient(string brokerHostName, int brokerPort, bool secure, X509Certificate caCert, X509Certificate clientCert, MqttSslProtocols sslProtocol,
-    RemoteCertificateValidationCallback userCertificateValidationCallback,
-    LocalCertificateSelectionCallback userCertificateSelectionCallback, List<string> ALPNProtocols)
+            LocalCertificateSelectionCallback userCertificateSelectionCallback,
+            List<string> ALPNProtocols = null)
         {
             this.Init(brokerHostName, brokerPort, secure, caCert, clientCert, sslProtocol, userCertificateValidationCallback, userCertificateSelectionCallback, ALPNProtocols);
         }
-
 #endif
 
 #if BROKER
@@ -436,7 +430,7 @@ namespace uPLibrary.Networking.M2Mqtt
         private void Init(string brokerHostName, int brokerPort, bool secure, X509Certificate caCert, X509Certificate clientCert, MqttSslProtocols sslProtocol,
             RemoteCertificateValidationCallback userCertificateValidationCallback,
             LocalCertificateSelectionCallback userCertificateSelectionCallback,
-            List<string> alpnProtocols)
+            List<string> alpnProtocols = null)
 #elif (WINDOWS_APP || WINDOWS_PHONE_APP)
         private void Init(string brokerHostName, int brokerPort, bool secure, MqttSslProtocols sslProtocol)
 #else

--- a/M2Mqtt/Net/MqttNetworkChannel.cs
+++ b/M2Mqtt/Net/MqttNetworkChannel.cs
@@ -31,6 +31,7 @@ using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 
 namespace uPLibrary.Networking.M2Mqtt
 {
@@ -83,6 +84,11 @@ namespace uPLibrary.Networking.M2Mqtt
         private SslStream sslStream;
 #if (!MF_FRAMEWORK_VERSION_V4_2 && !MF_FRAMEWORK_VERSION_V4_3)
         private NetworkStream netStream;
+
+        /// <summary>
+        /// List of Protocol for ALPN
+        /// </summary>
+        private List<string> alpnProtocols;
 #endif
 #endif
 
@@ -230,6 +236,17 @@ namespace uPLibrary.Networking.M2Mqtt
 #endif
         }
 
+#if !(MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK)
+        /// <param name="userCertificateSelectionCallback">A RemoteCertificateValidationCallback delegate responsible for validating the certificate supplied by the remote party</param>
+        /// <param name="userCertificateValidationCallback">A LocalCertificateSelectionCallback delegate responsible for selecting the certificate used for authentication</param>
+        public MqttNetworkChannel(string remoteHostName, int remotePort, bool secure, X509Certificate caCert, X509Certificate clientCert, MqttSslProtocols sslProtocol,
+            RemoteCertificateValidationCallback userCertificateValidationCallback,
+            LocalCertificateSelectionCallback userCertificateSelectionCallback, List<string> alpnProtocols)
+            : this(remoteHostName, remotePort, secure, caCert, clientCert, sslProtocol, userCertificateValidationCallback, userCertificateSelectionCallback)
+        {
+            this.alpnProtocols = alpnProtocols;
+        }
+#endif
         /// <summary>
         /// Connect to remote server
         /// </summary>
@@ -264,10 +281,38 @@ namespace uPLibrary.Networking.M2Mqtt
                 if (this.clientCert != null)
                     clientCertificates = new X509CertificateCollection(new X509Certificate[] { this.clientCert });
 #if (NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP3_1)
-                this.sslStream.AuthenticateAsClientAsync(this.remoteHostName,
-                    clientCertificates,
-                    MqttSslUtility.ToSslPlatformEnum(this.sslProtocol),
-                    false).Wait();
+
+                if ((this.alpnProtocols != null) && (0 < this.alpnProtocols.Count))
+                {
+                    this.sslStream = new SslStream(this.netStream, false);
+                    SslClientAuthenticationOptions authOptions = new SslClientAuthenticationOptions();
+                    List<SslApplicationProtocol> sslProtocolList = new List<SslApplicationProtocol>();
+                    foreach (string alpnProtocol in this.alpnProtocols)
+                    {
+                        sslProtocolList.Add(new SslApplicationProtocol(alpnProtocol));
+                    }
+                    authOptions.ApplicationProtocols = sslProtocolList;
+                    authOptions.EnabledSslProtocols = MqttSslUtility.ToSslPlatformEnum(this.sslProtocol);
+                    authOptions.TargetHost = remoteHostName;
+                    authOptions.AllowRenegotiation = false;
+                    authOptions.ClientCertificates = clientCertificates;
+                    authOptions.EncryptionPolicy = EncryptionPolicy.RequireEncryption;
+                    try
+                    {
+                        this.sslStream.AuthenticateAsClientAsync(authOptions).Wait();
+                    }
+                    catch(Exception ex)
+                    {
+                        throw ex;
+                    }
+                }
+                else
+                {
+                    this.sslStream.AuthenticateAsClientAsync(this.remoteHostName,
+                        clientCertificates,
+                        MqttSslUtility.ToSslPlatformEnum(this.sslProtocol),
+                        false).Wait();
+                }
 #else
                 this.sslStream.AuthenticateAsClient(this.remoteHostName,
                     clientCertificates,

--- a/M2Mqtt/Net/MqttNetworkChannel.cs
+++ b/M2Mqtt/Net/MqttNetworkChannel.cs
@@ -297,14 +297,8 @@ namespace uPLibrary.Networking.M2Mqtt
                     authOptions.AllowRenegotiation = false;
                     authOptions.ClientCertificates = clientCertificates;
                     authOptions.EncryptionPolicy = EncryptionPolicy.RequireEncryption;
-                    try
-                    {
-                        this.sslStream.AuthenticateAsClientAsync(authOptions).Wait();
-                    }
-                    catch(Exception ex)
-                    {
-                        throw ex;
-                    }
+
+                    this.sslStream.AuthenticateAsClientAsync(authOptions).Wait();
                 }
                 else
                 {

--- a/M2Mqtt/Net/MqttNetworkChannel.cs
+++ b/M2Mqtt/Net/MqttNetworkChannel.cs
@@ -186,7 +186,8 @@ namespace uPLibrary.Networking.M2Mqtt
         /// <param name="userCertificateValidationCallback">A LocalCertificateSelectionCallback delegate responsible for selecting the certificate used for authentication</param>
         public MqttNetworkChannel(string remoteHostName, int remotePort, bool secure, X509Certificate caCert, X509Certificate clientCert, MqttSslProtocols sslProtocol,
             RemoteCertificateValidationCallback userCertificateValidationCallback,
-            LocalCertificateSelectionCallback userCertificateSelectionCallback)
+            LocalCertificateSelectionCallback userCertificateSelectionCallback,
+            List<string> alpnProtocols = null)
 #else
         public MqttNetworkChannel(string remoteHostName, int remotePort, bool secure, X509Certificate caCert, X509Certificate clientCert, MqttSslProtocols sslProtocol)
 #endif
@@ -233,20 +234,10 @@ namespace uPLibrary.Networking.M2Mqtt
 #if !(MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK)
             this.userCertificateValidationCallback = userCertificateValidationCallback;
             this.userCertificateSelectionCallback = userCertificateSelectionCallback;
+            this.alpnProtocols = alpnProtocols;
 #endif
         }
 
-#if !(MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3 || COMPACT_FRAMEWORK)
-        /// <param name="userCertificateSelectionCallback">A RemoteCertificateValidationCallback delegate responsible for validating the certificate supplied by the remote party</param>
-        /// <param name="userCertificateValidationCallback">A LocalCertificateSelectionCallback delegate responsible for selecting the certificate used for authentication</param>
-        public MqttNetworkChannel(string remoteHostName, int remotePort, bool secure, X509Certificate caCert, X509Certificate clientCert, MqttSslProtocols sslProtocol,
-            RemoteCertificateValidationCallback userCertificateValidationCallback,
-            LocalCertificateSelectionCallback userCertificateSelectionCallback, List<string> alpnProtocols)
-            : this(remoteHostName, remotePort, secure, caCert, clientCert, sslProtocol, userCertificateValidationCallback, userCertificateSelectionCallback)
-        {
-            this.alpnProtocols = alpnProtocols;
-        }
-#endif
         /// <summary>
         /// Connect to remote server
         /// </summary>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ ATTENTION : .Net Micro Framework supports up to TLSV1
 *ALPN support*
 
 This library supports ALPN. You can connect to broker that provide ALPN connection like AWS IoT Core.
-If you connect to broker with ALPN, specify a protocol name. For example, you need to specify "x-amzn-mqtt-ca" as aprotocol name when you connect to AWS IoT Core with ALPN.
+If you connect to broker with ALPN, set a protocol name to "ALPNProtocols" paramerter. For example, you need to set "x-amzn-mqtt-ca" as a protocol name when you connect to AWS IoT Core with ALPN.
+
+note: ALPNProtocols parameter is list of string for protocol names.
 
 About ALPN: https://tools.ietf.org/html/rfc7301
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ However, you can leave the default project configuration and set "secure" parame
 
 ATTENTION : .Net Micro Framework supports up to TLSV1
 
+*ALPN support*
+
+This library supports ALPN. You can connect to broker that provide ALPN connection like AWS IoT Core.
+If you connect to broker with ALPN, specify a protocol name. For example, you need to specify "x-amzn-mqtt-ca" as aprotocol name when you connect to AWS IoT Core with ALPN.
+
+About ALPN: https://tools.ietf.org/html/rfc7301
+
+About AWS IoT Core ALPN:
+https://aws.amazon.com/jp/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/
+
 *Example*
 
 The M2Mqtt library provides a main class MqttClient that represents the MQTT client to connect to a broker. You can connect to the broker providing its IP address or host name and optionally some parameters related to MQTT protocol.


### PR DESCRIPTION
Add property of ALPN protocol names, and add constructor for use ALPN.

# summary
Hi, I'm simotin13, sorry for sending you a sudden pull request.
I'm using M2MqttDotnetCore for my application(.Net Core app).

In my Application, I need to access to AWS IoT Core MQTT Broker And It's support ALPN.
https://aws.amazon.com/about-aws/whats-new/2018/02/aws-iot-core-now-supports-mqtt-connections-with-certificate-based-client-authentication-on-port-443/?nc1=h_ls

I had to use ALPN, So I added ALPN feature to this repository.
https://github.com/simotin13/paho.mqtt.m2mqtt/tree/features/add_ALPN_support

I want merge my changes into repository if It's OK.
If my changes have any problems, I will fix them.

# Changes
2 files changed,
- MqttNetworkChannel.cs
- MqttClient.cs

## MqttNetworkChannel.cs
I add member property "alpnProtocols" for ALPN protocol names, And if alpnProtocols isn't empty connect to host using ALPN.
Also Add Constructor of MqttNetworkChannel, add argument for ALPN protocol names.

## MqttClient.cs
I changed Init method, add argument for for ALPN protocol names.

# sample and test
I create a sample project for checking my changes, and I tested that I able to use AWS ALPN.
https://github.com/simotin13/test_m2mqtt

The AWS ALPN Protocol Name is "x-amzn-mqtt-ca".
About AWS ALPN,
https://aws.amazon.com/blogs/iot/mqtt-with-tls-client-authentication-on-port-443-why-it-is-useful-and-how-it-works/

Also tested connet to local mosquitto broker for checking I don't brake repository code.
I tested without SSL/TLS connect(1883 port), with user/password connect, and SSL/TLS(8883 port) and It works and looks good to me.

Thank you.